### PR TITLE
Fix auth compatibility with ROS 6.43+

### DIFF
--- a/Mtik.pm
+++ b/Mtik.pm
@@ -293,18 +293,10 @@ sub login
         return 0;
     }
     my(@command);
-    push(@command,'/login');
-    my($retval,@results) = talk(\@command);
-    my($chal) = pack("H*",$results[0]{'ret'});
-    my($md) = new Digest::MD5;
-    $md->add(chr(0));
-    $md->add($passwd);
-    $md->add($chal);
-    my($hexdigest) = $md->hexdigest;
-    undef(@command);
+    my($retval,@results);
     push(@command, '/login');
     push(@command, '=name=' . $username);
-    push(@command, '=response=00' . $hexdigest);
+    push(@command, '=password=' . $passwd);
     ($retval,@results) = &talk(\@command);
     if ($retval > 1)
     {


### PR DESCRIPTION
In RouterOS version 6.43 a new form of plain authenticated was introduced.
In RouterOS version 6.45.1 the old authentication method as removed so we now need to use the form introduced in 6.43
see: https://wiki.mikrotik.com/wiki/Manual:API#Initial_login

This changes the steps done to login in the API becoming compatible with the new versions and incompatible with the old ones.

Please beware this library is still using plaintext authentication so isn't secure. Ill try to add HTTPS support when possible ...